### PR TITLE
Introduce `skipBuildChecks` flag

### DIFF
--- a/blueprints/ember-cli-addon-guard/files/config/addon-guard.js
+++ b/blueprints/ember-cli-addon-guard/files/config/addon-guard.js
@@ -1,8 +1,12 @@
 'use strict';
 
 module.exports = {
-  namespaceAddons: [
-  ],
+  /**
+   * If you only want to run ember-cli-addon-guard via its CLI, and not during
+   * every build, then set `skipBuildChecks: true`.
+   */
+  skipBuildChecks: false,
+
   /**
    * Normally, ember-cli-addon-guard will verify that every addon that depends
    * on calculate-cache-key-for-tree is using an updated version. This protects
@@ -13,6 +17,10 @@ module.exports = {
    */
   skipCacheKeyDependencyChecks: false,
 
+  /**
+   * List the names of any addons that you want ember-cli-addon-guard to
+   * completely ignore while it's checking for problems.
+   */
   ignoreAddons: [
   ]
 };

--- a/blueprints/ember-cli-addon-guard/files/config/addon-guard.js
+++ b/blueprints/ember-cli-addon-guard/files/config/addon-guard.js
@@ -3,6 +3,16 @@
 module.exports = {
   namespaceAddons: [
   ],
+  /**
+   * Normally, ember-cli-addon-guard will verify that every addon that depends
+   * on calculate-cache-key-for-tree is using an updated version. This protects
+   * against cache key calculations that may lead to excessive caching and
+   * duplication.
+   *
+   * To skip these checks, set `skipCacheKeyDependencyChecks: true`.
+   */
+  skipCacheKeyDependencyChecks: false,
+
   ignoreAddons: [
   ]
 };

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import readConfig from './lib/utils/read-config';
 import reviewProject, { ReviewProjectOptions } from './lib/utils/review-project';
 import dependentsToString from './lib/utils/dependents-to-string';
@@ -14,6 +15,12 @@ module.exports = {
 
   preBuild() {
     const config: AddonGuardConfig = this.addonGuardConfig;
+
+    if (config.skipBuildChecks) {
+      this.ui.writeLine(chalk.yellow('WARNING: ember-cli-addon-guard is configured to skip all checks during builds. To override this, set `skipBuildChecks: false` in `config/addon-guard.js`.'));
+      return;
+    }
+
     const options: ReviewProjectOptions = {
       ignoreAddons: config.ignoreAddons || [],
       runtimeOnly: true,

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ module.exports = {
       ignoreAddons: config.ignoreAddons || [],
       runtimeOnly: true,
       conflictsOnly: true,
-      skipCacheKeyDependencyCheck: config.skipCacheKeyDependencyCheck
+      skipCacheKeyDependencyChecks: config.skipCacheKeyDependencyChecks
     };
     const summary = reviewProject(this.project, options);
     const addons = summary.addons;

--- a/lib/commands/addon-guard.ts
+++ b/lib/commands/addon-guard.ts
@@ -18,7 +18,7 @@ module.exports = {
       ignoreAddons: config.ignoreAddons || [],
       runtimeOnly: true,
       conflictsOnly: true,
-      skipCacheKeyDependencyCheck: config.skipCacheKeyDependencyCheck
+      skipCacheKeyDependencyChecks: config.skipCacheKeyDependencyChecks
     };
     const summary = reviewProject(this.project, options);
     const addons = summary.addons;

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,4 +1,5 @@
 export interface AddonGuardConfig {
+  skipBuildChecks?: boolean;
   skipCacheKeyDependencyChecks?: boolean;
   ignoreAddons?: string[];
 }
@@ -19,5 +20,4 @@ export type AddonSummaries = Dict<AddonSummary>;
 export interface ProjectSummary {
   addons: Dict<AddonSummaries>;
   errors: string[];
-  // ignoredAddons: string[];
 }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,6 +1,6 @@
 export interface AddonGuardConfig {
+  skipCacheKeyDependencyChecks?: boolean;
   ignoreAddons?: string[];
-  skipCacheKeyDependencyCheck?: boolean;
 }
 
 export interface Dict<T = unknown> {

--- a/lib/utils/review-project.ts
+++ b/lib/utils/review-project.ts
@@ -26,7 +26,7 @@ export interface ReviewProjectOptions {
    *
    * Pass `true` to skip this check.
    */
-  skipCacheKeyDependencyCheck?: boolean;
+  skipCacheKeyDependencyChecks?: boolean;
 }
 
 /**
@@ -63,7 +63,7 @@ export default function reviewProject(project: any, options: ReviewProjectOption
     }
   }
 
-  if (!options.skipCacheKeyDependencyCheck) {
+  if (!options.skipCacheKeyDependencyChecks) {
     const version = cacheKeyDependencyVersion(project.dependencies(), project.root);
     if (version && !validateCacheKeyDependency(version)) {
       summary.errors.push(`This project has a dependency on 'calculate-cache-key-for-tree@${version}'. Update to v1.2.3 or later to avoid unnecessary addon duplication.`);
@@ -93,7 +93,7 @@ function traverseAddons(parentPath: string[], addons: any, summary: ProjectSumma
         keyedSummary.dependents.push(parentPath);
       }
 
-      if (!options.skipCacheKeyDependencyCheck) {
+      if (!options.skipCacheKeyDependencyChecks) {
         const version = cacheKeyDependencyVersion(addon.dependencies(), addon.root);
         if (version && !validateCacheKeyDependency(version)) {
           summary.errors.push(`The addon '${name}' has a dependency on 'calculate-cache-key-for-tree@${version}'. Update to v1.2.3 or later to avoid unnecessary addon duplication.`);

--- a/tests/unit/utils/review-project-test.ts
+++ b/tests/unit/utils/review-project-test.ts
@@ -292,7 +292,7 @@ describe('reviewProject', function() {
     fixturifyProject.addDependency('calculate-cache-key-for-tree', '1.2.0');
     const project = fixturifyProject.buildProjectModel();
 
-    expect(reviewProject(project, { skipCacheKeyDependencyCheck: true })).to.deep.equal({
+    expect(reviewProject(project, { skipCacheKeyDependencyChecks: true })).to.deep.equal({
       addons: {},
       errors: []
     });


### PR DESCRIPTION
The `skipBuildChecks` flag can be set in `config/addon-guard.js` to skip invoking ember-cli-addon guard during the `preBuild` step. Since this could lead to problems (which this addon attempts to avoid), a warning is displayed when this flag is set.

This PR also renames the recently introduced `skipCacheKeyDependencyCheck` flag to `skipCacheKeyDependencyChecks` for consistency.

Closes #8 