### PR TITLE
Improve addon-guard command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import readConfig from './lib/utils/read-config';
 import reviewProject, { ReviewProjectOptions } from './lib/utils/review-project';
 import dependentsToString from './lib/utils/dependents-to-string';
-import { AddonGuardConfig, AddonSummary, Dict } from './lib/interfaces';
+import { AddonGuardConfig, AddonVersionSummary, Dict } from './lib/interfaces';
 import SilentError from 'silent-error';
 
 module.exports = {
@@ -45,7 +45,7 @@ module.exports = {
         description += `Your application is dependent on multiple versions of the following run-time ${ conflictCount > 1 ? 'addons' : 'addon'}:\n`;
 
         for (const name in addons) {
-          const addonSummaries: Dict<AddonSummary> = addons[name];
+          const addonSummaries: Dict<AddonVersionSummary> = addons[name];
           description += `\n${name}\n----------------------------------------\n`;
           description += dependentsToString(name, addonSummaries);
         }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -10,14 +10,16 @@ export interface Dict<T = unknown> {
 
 export type path = string[];
 
-export interface AddonSummary {
+export interface AddonVersionSummary {
   version: string;
   dependents: path[];
+  cacheKey?: string;
+  runtime?: boolean;
 }
 
-export type AddonSummaries = Dict<AddonSummary>;
+export type AddonSummary = Dict<AddonVersionSummary>;
 
 export interface ProjectSummary {
-  addons: Dict<AddonSummaries>;
+  addons: Dict<AddonSummary>;
   errors: string[];
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "mocha tests/{unit,acceptance}/**/*-test.js",
+    "test": "mocha --require ts-node/register tests/{unit,acceptance}/**/*-test.ts",
     "prepare": "tsc",
     "clean": "git clean -x -f"
   },
@@ -24,7 +24,6 @@
     "archy": "^1.0.0",
     "broccoli-plugin": "^1.3.1",
     "chalk": "^2.4.2",
-    "ember-cli-addon-tests": "^0.11.0",
     "semver": "^6.0.0",
     "silent-error": "^1.1.1"
   },
@@ -36,13 +35,15 @@
     "@types/node": "^11.13.0",
     "chai": "^4.2.0",
     "ember-cli": "~3.8.1",
+    "ember-cli-addon-tests": "^0.11.1",
     "ember-cli-babel": "7.6.0",
     "ember-cli-dependency-checker": "^3.1.0",
     "eslint-plugin-node": "^7.0.1",
     "fixturify-project": "^1.8.0",
     "mocha": "^5.2.0",
     "strip-indent": "^2.0.0",
-    "typescript": "^3.4.2"
+    "ts-node": "^8.0.3",
+    "typescript": "^3.4.3"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/tests/acceptance/addon-guard-test.ts
+++ b/tests/acceptance/addon-guard-test.ts
@@ -1,0 +1,60 @@
+import { AddonTestApp } from 'ember-cli-addon-tests';
+import ConsoleUI from 'console-ui';
+import { expect } from 'chai';
+// import dedent from '../helpers/dedent';
+
+const ui = new ConsoleUI({
+  outputStream: process.stdout,
+  ci: process.env.CI,
+});
+
+describe('Acceptance: CLI', () => {
+  let app;
+
+  before(function() {
+    this.timeout(300000);
+
+    app = new AddonTestApp();
+
+    ui.startProgress('Creating dummy app...');
+    return app.create('test-app', { fixturesPath: 'tests/fixtures' }).then(() => {
+      ui.stopProgress();
+    });
+  });
+
+  describe('valid dependencies', () => {
+    beforeEach(() => {
+      app.editPackageJSON((pkg) => {
+        pkg['ember-addon'] = {
+          paths: [
+            'lib/addon-v1',
+            'lib/requires-v1',
+          ],
+        };
+      });
+    });
+
+    it('command exits with zero status and no output', function() {
+      this.timeout(10000);
+
+      return app.run('ember', 'addon-guard').then((result) => {
+        expect(result.code).to.equal(0);
+
+        const output = result.output.join('');
+        expect(output).to.include('ember-cli-addon-guard found no problems with your project.');
+      });
+    });
+
+    it('command includes all addons when requested', function() {
+      this.timeout(10000);
+
+      return app.run('ember', 'addon-guard', '--all').then((result) => {
+        expect(result.code).to.equal(0);
+
+        const output = result.output.join('');
+        expect(output).to.include('ember-cli-addon-guard identified ');
+        expect(output).to.include('ember-cli-addon-guard found no problems with your project.');
+      });
+    });
+  });
+});

--- a/tests/unit/utils/dependents-to-string-test.ts
+++ b/tests/unit/utils/dependents-to-string-test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import dedent from '../../helpers/dedent';
 import dependentsToString from '../../../lib/utils/dependents-to-string';
 
-describe('dependentsToString', function() {
+describe('Unit: dependentsToString', function() {
   it('prints simple trees', function() {
     const instances = {
       '123456': {

--- a/tests/unit/utils/dependents-to-string-test.ts
+++ b/tests/unit/utils/dependents-to-string-test.ts
@@ -79,17 +79,40 @@ describe('Unit: dependentsToString', function() {
     `);
   });
 
+  it('includes `runtime: true` if appropriate', function() {
+    const instances = {
+      '123': {
+        version: '1.0.0',
+        cacheKey: '123',
+        runtime: true,
+        dependents: [
+          ['foo'],
+          ['foo', 'bar'],
+        ]
+      }
+    };
+
+    expect(dependentsToString('my-addon', instances)).to.equal(dedent`
+      foo
+      ├── my-addon@1.0.0 (cacheKey: 123, runtime: true)
+      └─┬ bar
+        └── my-addon@1.0.0 (cacheKey: 123, runtime: true)
+    `);
+  });
+
   it('allows for custom formatting of the addon name', function() {
-    const printer = (version, cacheKey) => `${version}<->${version.split('').reverse().join('')} (cacheKey: ${cacheKey})`;
+    const printer = (version, cacheKey, runtime) => `${version}<->${version.split('').reverse().join('')} (cacheKey: ${cacheKey}, runtime: ${runtime})`;
     const instances = {
       '123456': {
         version: '1.0.0',
+        runtime: true,
         dependents: [
           ['foo']
         ]
       },
       'abcdef': {
         version: '2.3.4',
+        runtime: false,
         dependents: [
           ['foo', 'bar']
         ]
@@ -98,9 +121,9 @@ describe('Unit: dependentsToString', function() {
 
     expect(dependentsToString('my-addon', instances, printer)).to.equal(dedent`
       foo
-      ├── 1.0.0<->0.0.1 (cacheKey: 123456)
+      ├── 1.0.0<->0.0.1 (cacheKey: 123456, runtime: true)
       └─┬ bar
-        └── 2.3.4<->4.3.2 (cacheKey: abcdef)
+        └── 2.3.4<->4.3.2 (cacheKey: abcdef, runtime: false)
     `);
   });
 });

--- a/tests/unit/utils/is-runtime-addon-test.ts
+++ b/tests/unit/utils/is-runtime-addon-test.ts
@@ -2,7 +2,7 @@ import isRuntimeAddon from '../../../lib/utils/is-runtime-addon';
 import FixturifyProject from '../../helpers/fixturify-project';
 import { expect } from 'chai';
 
-describe('isRuntimeAddon', function() {
+describe('Unit: isRuntimeAddon', function() {
   it('returns true for addons if they have a non-empty `app` or `addon` directory', function() {
     const fixturifyProject = new FixturifyProject('root', '0.0.0');
     fixturifyProject.addDevDependency('ember-cli', '*');

--- a/tests/unit/utils/review-project-test.ts
+++ b/tests/unit/utils/review-project-test.ts
@@ -16,6 +16,7 @@ describe('Unit: reviewProject', function() {
           'foo:1.2.3': {
             version: '1.2.3',
             cacheKey: 'foo:1.2.3',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -23,6 +24,7 @@ describe('Unit: reviewProject', function() {
           'bar:1.0.0': {
             version: '1.0.0',
             cacheKey: 'bar:1.0.0',
+            runtime: false,
             dependents: [['root']]
           }
         }
@@ -46,6 +48,7 @@ describe('Unit: reviewProject', function() {
           'foo:1.2.3': {
             version: '1.2.3',
             cacheKey: 'foo:1.2.3',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -53,6 +56,7 @@ describe('Unit: reviewProject', function() {
           'bar:1.0.0': {
             version: '1.0.0',
             cacheKey: 'bar:1.0.0',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -60,6 +64,7 @@ describe('Unit: reviewProject', function() {
           'baz:5.0.1': {
             version: '5.0.1',
             cacheKey: 'baz:5.0.1',
+            runtime: false,
             dependents: [['root', 'bar']]
           }
         }
@@ -91,6 +96,7 @@ describe('Unit: reviewProject', function() {
           '1.2.3': {
             version: '1.2.3',
             cacheKey: '1.2.3',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -98,6 +104,7 @@ describe('Unit: reviewProject', function() {
           '1.0.0': {
             version: '1.0.0',
             cacheKey: '1.0.0',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -105,6 +112,7 @@ describe('Unit: reviewProject', function() {
           '5.0.1': {
             version: '5.0.1',
             cacheKey: '5.0.1',
+            runtime: false,
             dependents: [['root', 'bar']]
           }
         }
@@ -131,6 +139,7 @@ describe('Unit: reviewProject', function() {
           'foo:1.2.3': {
             version: '1.2.3',
             cacheKey: 'foo:1.2.3',
+            runtime: false,
             dependents: [
               ['root', 'bar', 'baz'],
               ['root', 'bar'],
@@ -142,6 +151,7 @@ describe('Unit: reviewProject', function() {
           'bar:1.0.0': {
             version: '1.0.0',
             cacheKey: 'bar:1.0.0',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -149,6 +159,7 @@ describe('Unit: reviewProject', function() {
           'baz:5.0.1': {
             version: '5.0.1',
             cacheKey: 'baz:5.0.1',
+            runtime: false,
             dependents: [['root', 'bar']]
           }
         }
@@ -175,16 +186,19 @@ describe('Unit: reviewProject', function() {
           'foo:1.2.3': {
             version: '1.2.3',
             cacheKey: 'foo:1.2.3',
+            runtime: false,
             dependents: [['root', 'bar', 'baz']]
           },
           'foo:1.2.5': {
             version: '1.2.5',
             cacheKey: 'foo:1.2.5',
+            runtime: false,
             dependents: [['root', 'bar']]
           },
           'foo:2.0.1': {
             version: '2.0.1',
             cacheKey: 'foo:2.0.1',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -192,6 +206,7 @@ describe('Unit: reviewProject', function() {
           'bar:1.0.0': {
             version: '1.0.0',
             cacheKey: 'bar:1.0.0',
+            runtime: false,
             dependents: [['root']]
           }
         },
@@ -199,6 +214,7 @@ describe('Unit: reviewProject', function() {
           'baz:5.0.1': {
             version: '5.0.1',
             cacheKey: 'baz:5.0.1',
+            runtime: false,
             dependents: [['root', 'bar']]
           }
         }
@@ -231,6 +247,7 @@ describe('Unit: reviewProject', function() {
           'bar:1.0.0': {
             version: '1.0.0',
             cacheKey: 'bar:1.0.0',
+            runtime: true,
             dependents: [['root']]
           }
         },
@@ -238,6 +255,7 @@ describe('Unit: reviewProject', function() {
           'baz:5.0.1': {
             version: '5.0.1',
             cacheKey: 'baz:5.0.1',
+            runtime: true,
             dependents: [['root', 'bar']]
           }
         }
@@ -264,6 +282,7 @@ describe('Unit: reviewProject', function() {
           'baz:5.0.1': {
             version: '5.0.1',
             cacheKey: 'baz:5.0.1',
+            runtime: false,
             dependents: [['root', 'bar']]
           }
         }
@@ -290,16 +309,19 @@ describe('Unit: reviewProject', function() {
           'foo:1.2.3': {
             version: '1.2.3',
             cacheKey: 'foo:1.2.3',
+            runtime: false,
             dependents: [['root', 'bar', 'baz']]
           },
           'foo:1.2.5': {
             version: '1.2.5',
             cacheKey: 'foo:1.2.5',
+            runtime: false,
             dependents: [['root', 'bar']]
           },
           'foo:2.0.1': {
             version: '2.0.1',
             cacheKey: 'foo:2.0.1',
+            runtime: false,
             dependents: [['root']]
           }
         }

--- a/tests/unit/utils/review-project-test.ts
+++ b/tests/unit/utils/review-project-test.ts
@@ -2,7 +2,7 @@ import reviewProject from '../../../lib/utils/review-project';
 import FixturifyProject from '../../helpers/fixturify-project';
 import { expect } from 'chai';
 
-describe('reviewProject', function() {
+describe('Unit: reviewProject', function() {
   it('emits the versions at the root', function() {
     const fixturifyProject = new FixturifyProject('root', '0.0.0');
     fixturifyProject.addDevDependency('ember-cli', '*');

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,6 +765,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
+  integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -1365,6 +1370,11 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
@@ -1929,7 +1939,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -1966,16 +1976,16 @@ electron-to-chromium@^1.3.116:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.119.tgz#9a7770da667252aeb81f667853f67c2b26e00197"
   integrity sha512-3mtqcAWa4HgG+Djh/oNXlPH0cOH6MmtwxN1nHSaReb9P0Vn51qYPqYwLeoSuAX9loU1wrOBhFbiX3CkeIxPfgg==
 
-ember-cli-addon-tests@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-addon-tests/-/ember-cli-addon-tests-0.11.0.tgz#7f5a07ce91317b9b06c792274e6d6a2cc43f1ee9"
-  integrity sha1-f1oHzpExe5sGx5InTm1qLMQ/Huk=
+ember-cli-addon-tests@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-addon-tests/-/ember-cli-addon-tests-0.11.1.tgz#70c9164cb4126b2d17bbf9588ff34d97d4bfbad1"
+  integrity sha512-PI3ht9NrgfAwBgh3aPCVecajndvDKltTqRdtxt5bgfQJ3+AMs6moXhijKygwuAeT5btyhhLbceTfHRL/K8pX2w==
   dependencies:
     chalk "^2.0.1"
     debug "^3.0.0"
     denodeify "^1.2.1"
     findup-sync "^2.0.0"
-    fs-extra "^4.0.2"
+    fs-extra "^5.0.0"
     lodash "^4.0.0"
     semver "^5.3.0"
     symlink-or-copy "^1.1.3"
@@ -3998,6 +4008,11 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-error@^1.1.1:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -5228,6 +5243,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.6:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
@@ -5250,7 +5273,7 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -5578,6 +5601,17 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+ts-node@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.0.3.tgz#aa60b836a24dafd8bf21b54766841a232fdbc641"
+  integrity sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==
+  dependencies:
+    arg "^4.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -5596,10 +5630,10 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.2.tgz#9ed4e6475d906f589200193be056f5913caed481"
-  integrity sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A==
+typescript@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
+  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -5895,3 +5929,8 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
+
+yn@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.0.tgz#fcbe2db63610361afcc5eb9e0ac91e976d046114"
+  integrity sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==


### PR DESCRIPTION
`ember addon-guard` command always shows errors in a similar form to when projects are built.

`ember addon-guard --all` will also show all addons, regardless of whether they are problematic. 