### PR TITLE
Ensure that package names are treated uniquely

### DIFF
--- a/lib/plugins/namespace-addon-imports-babel.ts
+++ b/lib/plugins/namespace-addon-imports-babel.ts
@@ -11,7 +11,7 @@ function namespacePath(path, state) {
   let namespacedPath;
 
   // Ignore any packages we're not targetting
-  if (!source.startsWith(name)) {
+  if (source !== name && !source.startsWith(`${name}/`) ) {
     return;
 
   // Use custom handling for template paths, which need to have `templates`


### PR DESCRIPTION
Fixes import rewrite errors that occur when addons share the same initial name (e.g. `my-addon` and `my-addon-two`).