### PR TITLE
Do not report addons with different cachekey but same version & adding summary to output

### DIFF
--- a/lib/commands/addon-guard.ts
+++ b/lib/commands/addon-guard.ts
@@ -52,7 +52,7 @@ module.exports = {
     if (Object.keys(duplicateAddons).length > 0 || summary.errors.length > 0) {
       if (Object.keys(duplicateAddons).length > 0) {
         this.ui.writeLine(chalk.red(chalk.underline('Summary')));
-        this.ui.writeLine(chalk.red(`Number of addons with multiple verions: ${ addonCount }\n`));
+        this.ui.writeLine(chalk.red(`Number of addons with multiple versions: ${ addonCount }\n`));
         for (const name in duplicateAddons) {
           const addonInstances: Dict<AddonVersionSummary> = duplicateAddons[name];
           const versions = new Set();

--- a/lib/commands/addon-guard.ts
+++ b/lib/commands/addon-guard.ts
@@ -51,6 +51,19 @@ module.exports = {
 
     if (Object.keys(duplicateAddons).length > 0 || summary.errors.length > 0) {
       if (Object.keys(duplicateAddons).length > 0) {
+        this.ui.writeLine(chalk.red(chalk.underline('Summary')));
+        this.ui.writeLine(chalk.red(`Number of addons with multiple verions: ${ addonCount }\n`));
+        for (const name in duplicateAddons) {
+          const addonInstances: Dict<AddonVersionSummary> = duplicateAddons[name];
+          const versions = new Set();
+          for (const cacheKey of Object.keys(addonInstances)) {
+            const instance = addonInstances[cacheKey];
+            versions.add(instance.version);
+          }
+          this.ui.writeLine(chalk.red(`${name}: [${Array.from(versions.values()).join(' , ')}]`));
+        }
+
+        this.ui.writeLine(chalk.red(chalk.underline('\nDetails')));
         this.ui.writeLine(chalk.red(`ember-cli-addon-guard determined that your application is dependent on multiple versions of the following run-time ${ addonCount > 1 ? 'addons' : 'addon'}:\n`));
 
         for (const name in duplicateAddons) {

--- a/lib/utils/review-project.ts
+++ b/lib/utils/review-project.ts
@@ -61,7 +61,7 @@ export default function reviewProject(project: any, options: ReviewProjectOption
 
   if (options.conflictsOnly) {
     for (const name in addons) {
-      if (Object.keys(addons[name]).length < 2) {
+      if (Object.keys(addons[name]).length < 2 || isSameVersion(addons[name])) {
         delete addons[name];
       }
     }
@@ -76,6 +76,15 @@ export default function reviewProject(project: any, options: ReviewProjectOption
 
   return summary;
 };
+
+// check for different cache key with the same versions
+function isSameVersion(addon: any) {
+  const versions = new Set();
+  for (const summary in addon) {
+    versions.add(addon[summary].version);
+  }
+  return versions.size === 1;
+}
 
 function traverseAddons(parentPath: string[], addons: any, summary: ProjectSummary, options: ReviewProjectOptions) {
   for (const addon of addons) {

--- a/tests/helpers/fixturify-project.ts
+++ b/tests/helpers/fixturify-project.ts
@@ -11,9 +11,10 @@ class ProjectWithoutInternalAddons extends Project {
   }
 }
 
-function prepareAddon(addon: any) {
+function prepareAddon(addon: any, cacheKeyForTree: string) {
   addon.pkg.keywords.push('ember-addon');
   addon.pkg['ember-addon'] = { };
+  addon.pkg['cacheKey'] = cacheKeyForTree;
   addon.files['index.js'] = 'module.exports = { name: require("./package").name };';
 }
 
@@ -53,9 +54,9 @@ export default class EmberCLIFixturifyProject extends FixturifyProject {
     return project;
   }
 
-  addAddon(name: string, version = '0.0.0', cb?: (addon: any) => void) {
+  addAddon(name: string, version = '0.0.0', cb?: (addon: any) => void, cacheKeyForTree?: string) {
     return this.addDependency(name, version, addon => {
-      prepareAddon(addon);
+      prepareAddon(addon, cacheKeyForTree);
 
       if (cb) {
         cb(addon);
@@ -63,9 +64,9 @@ export default class EmberCLIFixturifyProject extends FixturifyProject {
     });
   }
 
-  addDevAddon(name: string, version = '0.0.0', cb?: (addon: any) => void) {
+  addDevAddon(name: string, version = '0.0.0', cb?: (addon: any) => void, cacheKeyForTree?: string) {
     return this.addDevDependency(name, version, addon => {
-      prepareAddon(addon);
+      prepareAddon(addon, cacheKeyForTree);
       if (cb) {
         cb(addon);
       }


### PR DESCRIPTION
This PR fixes a bug and adds a new summary section to the output

1. Some addons may return a custom cachekey, in my example, the addon returns a different cachekey if an addon is declared from the root vs as child's dependent. ECAG(Ember-cli-addon-guard) reported that addon as a failure, when the version is actually the same. Fix was to have ECAG to also check for version.
2. Having a summary section on the top of the output helps with parsing all the information easily.
eg:
```
Summary
Number of addons with multiple versions: 16

@embroider/macros: [0.36.0 , 0.24.1]
ember-get-config: [0.2.4 , 0.3.0]
ember-lifeline: [4.1.5 , 3.1.1 , 5.1.0 , 6.0.1]
ember-test-selectors: [5.0.0 , 3.0.0]
ember-batcher: [3.0.0 , 4.0.1]

Details
ember-cli-addon-guard determined that your application is dependent on multiple versions of the following run-time addons:

@embroider/macros
...
```